### PR TITLE
Add strike-through font-lock; fix citation e-mail bug

### DIFF
--- a/pandoc-mode.el
+++ b/pandoc-mode.el
@@ -1197,6 +1197,12 @@ _M_: Use current file as master file
 (defvar pandoc-citation-brackets-face 'pandoc-citation-brackets-face
   "Face name to use for page numbers and other notation.")
 
+(defvar pandoc-strikethrough-text-face 'pandoc-strikethrough-text-face
+  "Face name to use for strikethrough text.")
+
+(defvar pandoc-strikethrough-tilde-face 'pandoc-strikethrough-tilde-face
+  "Face name to use for strikethrough tilde syntax.")
+
 (defface pandoc-citation-key-face
   '((t (:inherit font-lock-function-name-face)))
   "Base face for pandoc citations."
@@ -1217,6 +1223,16 @@ _M_: Use current file as master file
   "Base face for pandoc citation brackets."
   :group 'pandoc)
 
+(defface pandoc-strikethrough-text-face
+  '((t (:strike-through t)))
+  "Base face for pandoc strikethrough text."
+  :group 'pandoc)
+
+(defface pandoc-strikethrough-tilde-face
+  '((t (:inherit font-lock-warning-face)))
+  "Base face for pandoc citation brackets."
+  :group 'pandoc)
+
 (defconst pandoc-regex-parenthetical-citation-single
   "\\(\\[\\)\\(-?@\\)\\([-a-zA-Z0-9_+:]*\\)\\(\\]\\)"
   "Regular expression for parenthetical citations with only one key.")
@@ -1233,8 +1249,16 @@ _M_: Use current file as master file
   "\\(-?@\\)\\([-a-zA-Z0-9_+:]*\\)"
   "Regular expression for stand-alone citation with no anchor.")
 
+(defconst pandoc-regex-strikethrough
+  "\\(~~\\)\\(.*?\\)\\(~~\\)"
+  "Regular expression for stand-alone citation with no anchor.")
+
 (defvar pandoc-faces-keywords
   (list
+   (cons pandoc-regex-strikethrough
+	 '((1 pandoc-strikethrough-tilde-face keep)
+	   (2 pandoc-strikethrough-text-face keep)
+	   (3 pandoc-strikethrough-tilde-face keep)))
    (cons pandoc-regex-parenthetical-citation-single
    	 '((1 pandoc-citation-brackets-face t)
    	   (2 pandoc-citation-marker-face)

--- a/pandoc-mode.el
+++ b/pandoc-mode.el
@@ -1201,7 +1201,7 @@ _M_: Use current file as master file
   "Face name to use for strikethrough text.")
 
 (defvar pandoc-strikethrough-tilde-face 'pandoc-strikethrough-tilde-face
-  "Face name to use for strikethrough tilde syntax.")
+  "Face name to use for strikethrough delimiters.")
 
 
 (defface pandoc-citation-key-face
@@ -1251,15 +1251,11 @@ _M_: Use current file as master file
   "Regular expression for stand-alone citation with no anchor.")
 
 (defconst pandoc-regex-strikethrough
-  "\\(~~\\)\\(.*?\\)\\(~~\\)"
+  "\\(~\\{2\\}\\)\\([^~].*?\\)\\(~\\{2\\}\\)"
   "Regular expression for pandoc markdown's strikethrough syntax.")
 
 (defvar pandoc-faces-keywords
   (list
-   (cons pandoc-regex-strikethrough
-   	 '((1 pandoc-strikethrough-tilde-face )
-   	   (2 pandoc-strikethrough-text-face )
-   	   (3 pandoc-strikethrough-tilde-face )))
    (cons pandoc-regex-parenthetical-citation-single
    	 '((1 pandoc-citation-brackets-face t)
    	   (2 pandoc-citation-marker-face)
@@ -1279,7 +1275,11 @@ _M_: Use current file as master file
 	   (5 pandoc-citation-brackets-face)))
    (cons pandoc-regex-in-text-citation-2
 	 '((1 pandoc-citation-marker-face t)
-	   (2 pandoc-citation-key-face t))))
+	   (2 pandoc-citation-key-face t)))
+   (cons pandoc-regex-strikethrough
+   	 '((1 pandoc-strikethrough-tilde-face)
+   	   (2 pandoc-strikethrough-text-face )
+   	   (3 pandoc-strikethrough-tilde-face))))
   "Keywords for pandoc faces.")
 
 (defun pandoc-faces-load ()

--- a/pandoc-mode.el
+++ b/pandoc-mode.el
@@ -1203,6 +1203,7 @@ _M_: Use current file as master file
 (defvar pandoc-strikethrough-tilde-face 'pandoc-strikethrough-tilde-face
   "Face name to use for strikethrough tilde syntax.")
 
+
 (defface pandoc-citation-key-face
   '((t (:inherit font-lock-function-name-face)))
   "Base face for pandoc citations."
@@ -1230,7 +1231,7 @@ _M_: Use current file as master file
 
 (defface pandoc-strikethrough-tilde-face
   '((t (:inherit font-lock-warning-face)))
-  "Base face for pandoc citation brackets."
+  "Base face for pandoc strikethrough delimiters."
   :group 'pandoc)
 
 (defconst pandoc-regex-parenthetical-citation-single
@@ -1246,19 +1247,19 @@ _M_: Use current file as master file
   "Regular expression for stand-alone citation with anchor.")
 
 (defconst pandoc-regex-in-text-citation-2
-  "\\(-?@\\)\\([-a-zA-Z0-9_+:]*\\)"
+  "\\<\\(-?@\\)\\([-a-zA-Z0-9_+:]*\\)"
   "Regular expression for stand-alone citation with no anchor.")
 
 (defconst pandoc-regex-strikethrough
   "\\(~~\\)\\(.*?\\)\\(~~\\)"
-  "Regular expression for stand-alone citation with no anchor.")
+  "Regular expression for pandoc markdown's strikethrough syntax.")
 
 (defvar pandoc-faces-keywords
   (list
    (cons pandoc-regex-strikethrough
-	 '((1 pandoc-strikethrough-tilde-face keep)
-	   (2 pandoc-strikethrough-text-face keep)
-	   (3 pandoc-strikethrough-tilde-face keep)))
+   	 '((1 pandoc-strikethrough-tilde-face )
+   	   (2 pandoc-strikethrough-text-face )
+   	   (3 pandoc-strikethrough-tilde-face )))
    (cons pandoc-regex-parenthetical-citation-single
    	 '((1 pandoc-citation-brackets-face t)
    	   (2 pandoc-citation-marker-face)
@@ -1277,8 +1278,8 @@ _M_: Use current file as master file
 	   (4 pandoc-citation-extra-face)
 	   (5 pandoc-citation-brackets-face)))
    (cons pandoc-regex-in-text-citation-2
-	 '((1 pandoc-citation-marker-face prepend)
-	   (2 pandoc-citation-key-face prepend))))
+	 '((1 pandoc-citation-marker-face t)
+	   (2 pandoc-citation-key-face t))))
   "Keywords for pandoc faces.")
 
 (defun pandoc-faces-load ()


### PR DESCRIPTION
I have added strike-through to pandoc-mode's font-lock highlighting. The tilde delimiters and the struck text can be font-locked separately.

While doing this, I noticed that citation font-locking
1) highlighted e-mail addresses and
2) interrupted other markdown font-locking (in my case, a fenced-code region containing an e-mail 
address). This should be fixed.

![pandoc-mode_strike-through](https://cloud.githubusercontent.com/assets/5402228/7396912/6bb892dc-ee6a-11e4-9d86-f81d9229e540.png)

Have a nice day!