### PR TITLE
New feature: reference jumping

### DIFF
--- a/pandoc-mode-utils.el
+++ b/pandoc-mode-utils.el
@@ -117,6 +117,20 @@ list, not if it appears higher on the list."
   :group 'pandoc
   :type 'string)
 
+(defcustom pandoc-citation-jump-function 'pandoc-goto-citation-reference
+  "Function used to locate bibtex reference from citation key.
+
+This function is given two arguments:
+
+1) A list of BIBLIOGRAPHY files
+2) The string that matches the citation KEY at point
+
+It should direct the user to a bibliographic reference that matches KEY.
+
+The default is `pandoc-goto-citation'"
+  :group 'pandoc
+  :type 'function)
+
 (defcustom pandoc-major-modes
   '((haskell-mode . "native")
     (text-mode . "markdown")

--- a/pandoc-mode.el
+++ b/pandoc-mode.el
@@ -1440,10 +1440,9 @@ _M_: Use current file as master file
   (loop for bibfile in biblist
 	if (with-temp-buffer
 	     (insert-file-contents bibfile)
-	     (re-search-forward (concat
-				 "@[a-zA-Z]*[{(][[:space:]]*"
-				 key) nil t))
-	do (let ((buf (get-file-buffer bibfile)))
+	     (re-search-forward
+	      (concat "@[a-zA-Z]*[{(][[:space:]]*" key) nil t))
+	finally do (let ((buf (get-file-buffer bibfile)))
 		  (if buf
 		      (switch-to-buffer-other-window buf)
 		    (find-file-other-window bibfile)))

--- a/pandoc-mode.el
+++ b/pandoc-mode.el
@@ -1447,15 +1447,17 @@ The default is `pandoc-goto-citation'"
   (loop for bibfile in biblist
 	if (with-temp-buffer
 	     (insert-file-contents bibfile)
-	     (search-forward key nil t))
-	
+	     (re-search-forward (concat
+				 "@[a-zA-Z]*[{(][[:space:]]*"
+				 key) nil t))
 	do (let ((buf (get-file-buffer bibfile)))
 		  (if buf
 		      (switch-to-buffer-other-window buf)
 		    (find-file-other-window bibfile)))
 	(with-current-buffer (get-file-buffer bibfile))
 	(goto-char (point-min))
-	(search-forward key)))
+	(re-search-forward
+	 (concat "@[a-zA-Z]*[{(][[:space:]]*" key) nil t)))
 
 (defun pandoc-jump-to-reference ()
   "Jump to bibtex reference for citation at point."

--- a/pandoc-mode.el
+++ b/pandoc-mode.el
@@ -1255,6 +1255,9 @@ _M_: Use current file as master file
 ;;; Overall structure modeled after face handling in markdown-mode.el:
 ;;; http://jblevins.org/git/markdown-mode.git
 
+(defgroup pandoc nil
+  "Minor mode for pandoc.")
+
 (defvar pandoc-citation-key-face 'pandoc-citation-key-face
   "Face name to use for citations.")
 
@@ -1413,17 +1416,30 @@ _M_: Use current file as master file
 ;;; Citation jumping:
 ;;; Jump to citation in a bibliography file.
 
+
+(defcustom pandoc-citation-jump-function 'pandoc-goto-citation-reference
+  "This function is given two arguments.
+
+1) A list of BIBLIOGRAPHY files
+2) The string that matches the citation KEY at point
+
+It should direct the user to a bibliographic reference that matches KEY.
+
+The default is `pandoc-goto-citation'"
+  :group 'pandoc
+  :type 'function)
+
 (defun pandoc-citation-at-point (biblist)
-  "Retrieve citation key at point, if any, and pass it, along with BIBLIST, to `pandoc-citation-goto-reference."
+  "Retrieve citation key at point, if any, and pass it, along with BIBLIST, to the display function stored in the variable `pandoc-citation-jump-functino'."
   (cond
    ((thing-at-point-looking-at pandoc-regex-in-text-citation)
-     (pandoc-goto-citation-reference biblist (match-string-no-properties 4)))
+     (funcall pandoc-citation-jump-function biblist (match-string-no-properties 4)))
    ((thing-at-point-looking-at pandoc-regex-in-text-citation-2)
-    (pandoc-goto-citation-reference biblist (match-string-no-properties 2)))
+    (funcall pandoc-citation-jump-function biblist (match-string-no-properties 2)))
    ((thing-at-point-looking-at pandoc-regex-parenthetical-citation-single)
-    (pandoc-goto-citation-reference biblist (match-string-no-properties 3)))
+    (funcall pandoc-citation-jump-function biblist (match-string-no-properties 3)))
    ((thing-at-point-looking-at pandoc-regex-parenthetical-citation-multiple)
-    (pandoc-goto-citation-reference biblist (match-string-no-properties 4)))
+    (funcall pandoc-citation-jump-function biblist (match-string-no-properties 4)))
    (t (error "No citation at point"))))
 	
 (defun pandoc-goto-citation-reference (biblist key)

--- a/pandoc-mode.el
+++ b/pandoc-mode.el
@@ -1255,9 +1255,6 @@ _M_: Use current file as master file
 ;;; Overall structure modeled after face handling in markdown-mode.el:
 ;;; http://jblevins.org/git/markdown-mode.git
 
-(defgroup pandoc nil
-  "Minor mode for pandoc.")
-
 (defvar pandoc-citation-key-face 'pandoc-citation-key-face
   "Face name to use for citations.")
 
@@ -1416,21 +1413,17 @@ _M_: Use current file as master file
 ;;; Citation jumping:
 ;;; Jump to citation in a bibliography file.
 
-
-(defcustom pandoc-citation-jump-function 'pandoc-goto-citation-reference
-  "This function is given two arguments.
-
-1) A list of BIBLIOGRAPHY files
-2) The string that matches the citation KEY at point
-
-It should direct the user to a bibliographic reference that matches KEY.
-
-The default is `pandoc-goto-citation'"
-  :group 'pandoc
-  :type 'function)
+(defun pandoc-jump-to-reference ()
+  "Jump to bibtex reference for citation at point."
+  (interactive)
+  (let
+      ((biblist (pandoc--get 'bibliography)))
+   (if biblist
+	(pandoc-citation-at-point biblist)
+      (error "No bibliography selected"))))
 
 (defun pandoc-citation-at-point (biblist)
-  "Retrieve citation key at point, if any, and pass it, along with BIBLIST, to the display function stored in the variable `pandoc-citation-jump-functino'."
+  "Retrieve citation key at point, if any, and pass it, along with BIBLIST, to the display function stored in the variable `pandoc-citation-jump-function'."
   (cond
    ((thing-at-point-looking-at pandoc-regex-in-text-citation)
      (funcall pandoc-citation-jump-function biblist (match-string-no-properties 4)))
@@ -1459,14 +1452,6 @@ The default is `pandoc-goto-citation'"
 	(re-search-forward
 	 (concat "@[a-zA-Z]*[{(][[:space:]]*" key) nil t)))
 
-(defun pandoc-jump-to-reference ()
-  "Jump to bibtex reference for citation at point."
-  (interactive)
-  (let
-      ((biblist (pandoc--get 'bibliography)))
-   (if biblist
-	(pandoc-citation-at-point biblist)
-      (error "No bibliography selected"))))
 
 (provide 'pandoc-mode)
 

--- a/pandoc-mode.info
+++ b/pandoc-mode.info
@@ -427,6 +427,12 @@ feature may be bound to a key combination as follows:
 
 (define-key markdown-mode-map (kbd "C-c j") 'pandoc-jump-to-reference)
 
+The jump behavior may be customized:
+
+(setq pandoc-citation-jump-function 'my-pandoc-jump-function)
+
+The default behavior is to open (or locate) the appropriate .bib file in another window and position the cursor at the indicated bibliographic key.
+
 
 File: pandoc-mode.info,  Node: Font lock,  Next: Settings Files,  Prev: Usage,  Up: Top
 

--- a/pandoc-mode.info
+++ b/pandoc-mode.info
@@ -415,6 +415,18 @@ instead by customising ‘pandoc-process-connection-type’.  Alternatively,
 you can use a synchronous process by unsetting the user option
 ‘pandoc-use-async’.
 
+3.8 Citation Jumping
+====================
+
+Pandoc-mode provides the function ‘pandoc-jump-to-reference‘ that
+locates a reference within external bibliography files indicated by
+the ‘bibliography‘ user option. Note that entries to the
+‘bibliography‘ user option list must have a valid path
+(i.e. "./Bibliography.bib" rather than "Bibliography.bib"). This
+feature may be bound to a key combination as follows:
+
+(define-key markdown-mode-map (kbd "C-c j") 'pandoc-jump-to-reference)
+
 
 File: pandoc-mode.info,  Node: Font lock,  Next: Settings Files,  Prev: Usage,  Up: Top
 


### PR DESCRIPTION
This PR includes `pandoc-jump-to-reference` and supporting functions that identify a citation key at point and jump to its reference in the appropriate bibliography file. Using the "bibliography" user option, this feature works even if multiple files are specified.

I also updated the info file to include a brief description of the feature, along with instructions for binding the function to a key.
