### PR TITLE
Fix key collision between MimeTeX and MathML.

### DIFF
--- a/pandoc-mode-utils.el
+++ b/pandoc-mode-utils.el
@@ -1210,7 +1210,7 @@ evaluated."
 (define-pandoc-string-option katex-stylesheet (math "K" "%-18s") "KaTeX Stylesheet"    'default)
 (define-pandoc-string-option katex            (math "k" "%-18s") "KaTeX URL"           'default)
 (define-pandoc-string-option webtex           (math "w" "%-18s") "WebTeX URL"          'default)
-(define-pandoc-string-option mimetex          (math "m" "%-18s") "MimeTeX CGI Script*" 'default)
+(define-pandoc-string-option mimetex          (math "M" "%-18s") "MimeTeX CGI Script*" 'default)
 (define-pandoc-switch        gladtex          (math "g" "%-18s") "gladTeX")
 (define-pandoc-string-option mathjax          (math "J" "%-18s") "MathJax URL"         'default)
 (define-pandoc-string-option jsmath           (math "j" "%-18s") "jsMath URL*"         'default)


### PR DESCRIPTION
Both MimeTex and MathML options were mapped to "m".
Changed MimeTex to "M" to avoid collision.