### PR TITLE
Change the parent group of the customization group

### DIFF
--- a/pandoc-mode-utils.el
+++ b/pandoc-mode-utils.el
@@ -46,7 +46,9 @@
 (require 'dash)
 (require 'cl-lib)
 
-(defgroup pandoc nil "Minor mode for interacting with pandoc." :group 'wp)
+(defgroup pandoc nil
+  "Minor mode for interacting with pandoc."
+  :group 'text)
 
 (defcustom pandoc-binary "pandoc"
   "The name of the pandoc binary.


### PR DESCRIPTION
* pandoc-mode-utils.el: The `wp` group is deprecated.  Furthermore, the `text` group should be more appropriate.