### PR TITLE
Add option to output to xwiki markup

### DIFF
--- a/pandoc-mode-utils.el
+++ b/pandoc-mode-utils.el
@@ -197,6 +197,7 @@ matches KEY."
      ("tikiwiki"               "TikiWiki"                     "t" both)
      ("twiki"                  "Twiki"                        "T" input)
      ("vimwiki"                "Vimwiki"                      "v" both)
+     ("xwiki"                  "Xwiki"                        "x" output)
      ("zimwiki"                "ZimWiki"                      "z" both))
 
     ("wordprocessor" "Wordprocessor Formats" "W"


### PR DESCRIPTION
xwiki is a supported output format: https://pandoc.org/MANUAL.html