### PR TITLE
fix: fix incorrect parenthesis nesting in cond

### DIFF
--- a/pandoc-mode-utils.el
+++ b/pandoc-mode-utils.el
@@ -857,8 +857,8 @@ as argument."
                (cond
                 ((eq prefix '-)     ; C-u - or M--
                  nil)
-                ((and (listp prefix)
-                      (= (car prefix) 16)) ; C-u C-u
+                ((and (listp prefix))
+                 (= (car prefix) 16) ; C-u C-u
                  (read-string (concat prompt ": ")))
                 ;; otherwise no prefix or C-u
                 (t (pandoc--read-file-name (concat prompt ": ") default-directory (not prefix))))))


### PR DESCRIPTION
Related issues:

- #127 

The reason for the bug above is that the right parentheses of `(and ...)` was mistakenly put after the `(= ...)`. Therefore no matter whether `prefix` is nil or list, it would always attempt to call `(= (car prefix) 16)` and throw an error "wrong type argument: number-or-marker-p nil".